### PR TITLE
Fix meta for blocks

### DIFF
--- a/src/MyPlot/MyPlotGenerator.php
+++ b/src/MyPlot/MyPlotGenerator.php
@@ -47,11 +47,11 @@ class MyPlotGenerator extends Generator
 
         $this->settings = [];
         $this->settings["preset"] = json_encode([
-            "RoadBlock" => $this->roadBlock->getId() . (($meta = $this->roadBlock->getDamage()) ? '' : ':'.$meta),
-            "WallBlock" => $this->wallBlock->getId() . (($meta = $this->wallBlock->getDamage()) ? '' : ':'.$meta),
-            "PlotFloorBlock" => $this->plotFloorBlock->getId() . (($meta = $this->plotFloorBlock->getDamage()) ? '' : ':'.$meta),
-            "PlotFillBlock" => $this->plotFillBlock->getId() . (($meta =$this->plotFillBlock->getDamage()) ? '' : ':'.$meta),
-            "BottomBlock" => $this->bottomBlock->getId() . (($meta = $this->bottomBlock->getDamage()) ? '' : ':'.$meta),
+            "RoadBlock" => $this->roadBlock->getId() . (($meta = $this->roadBlock->getDamage()) === 0 ? '' : ':'.$meta),
+            "WallBlock" => $this->wallBlock->getId() . (($meta = $this->wallBlock->getDamage()) === 0 ? '' : ':'.$meta),
+            "PlotFloorBlock" => $this->plotFloorBlock->getId() . (($meta = $this->plotFloorBlock->getDamage()) === 0 ? '' : ':'.$meta),
+            "PlotFillBlock" => $this->plotFillBlock->getId() . (($meta =$this->plotFillBlock->getDamage()) === 0 ? '' : ':'.$meta),
+            "BottomBlock" => $this->bottomBlock->getId() . (($meta = $this->bottomBlock->getDamage()) === 0 ? '' : ':'.$meta),
             "RoadWidth" => $this->roadWidth,
             "PlotSize" => $this->plotSize,
             "GroundHeight" => $this->groundHeight,


### PR DESCRIPTION
Found this bug while trying to add things (like a block in the center of the cross of 2 roads)
The meta is defined as zero, thats what the fix is for now.
You could also remove the whole meta check, also meta 0 is a meta